### PR TITLE
Add test for consecutive rescue attempts

### DIFF
--- a/tests/path.js.test.html
+++ b/tests/path.js.test.html
@@ -8,7 +8,8 @@
 		  "#A",
 			"#B",
 			"#C",
-			"#D",
+			"#D1",
+			"#D2",
 			"#E/params/1/parse",
 			"#E/params/2/parse",
 			"#E/params/3/check",
@@ -68,7 +69,8 @@
 			    update("C[exit]");
 			});
 			
-			// No map for #D.  This checks that our rescue method works.
+			// No map for #D1.  This checks that our rescue method works.
+			// No map for #D2.  This checks that our rescue method works consecutively.
 			
 			Path.map("#E/params/:id/parse").to(function(){
 			    update("E[action](parse id=" + this.params['id'] + ")");
@@ -164,7 +166,7 @@
 		</div><br /><br />
 		<div id="console">
 		    <h3>Expected</h3>
-		    <div id="expected">F[enter]::F[action]::A[enter]::A[action]::A[exit]::B[enter]::B[action]::C[action]::C[exit]::RESCUE::E[enter](parse)::E[action](parse id=1)::E[enter](parse)::E[action](parse id=2)::E[action](check id=3)::E[exit](check)::F[enter]::F[action]::G[enter 1]::G[enter 2]::G[enter 3]::G[enter 4]</div>
+		    <div id="expected">F[enter]::F[action]::A[enter]::A[action]::A[exit]::B[enter]::B[action]::C[action]::C[exit]::RESCUE::RESCUE::E[enter](parse)::E[action](parse id=1)::E[enter](parse)::E[action](parse id=2)::E[action](check id=3)::E[exit](check)::F[enter]::F[action]::G[enter 1]::G[enter 2]::G[enter 3]::G[enter 4]</div>
 			<h3>Actual</h3>
 			<div id="actual"></div>
 			<h3>Grade</h3>

--- a/tests/path.min.js.test.html
+++ b/tests/path.min.js.test.html
@@ -8,7 +8,8 @@
 		  "#A",
 			"#B",
 			"#C",
-			"#D",
+			"#D1",
+			"#D2",
 			"#E/params/1/parse",
 			"#E/params/2/parse",
 			"#E/params/3/check",
@@ -68,7 +69,8 @@
 			    update("C[exit]");
 			});
 			
-			// No map for #D.  This checks that our rescue method works.
+			// No map for #D1.  This checks that our rescue method works.
+			// No map for #D2.  This checks that our rescue method works consecutively.
 			
 			Path.map("#E/params/:id/parse").to(function(){
 			    update("E[action](parse id=" + this.params['id'] + ")");
@@ -164,7 +166,7 @@
 		</div><br /><br />
 		<div id="console">
 		    <h3>Expected</h3>
-		    <div id="expected">F[enter]::F[action]::A[enter]::A[action]::A[exit]::B[enter]::B[action]::C[action]::C[exit]::RESCUE::E[enter](parse)::E[action](parse id=1)::E[enter](parse)::E[action](parse id=2)::E[action](check id=3)::E[exit](check)::F[enter]::F[action]::G[enter 1]::G[enter 2]::G[enter 3]::G[enter 4]</div>
+		    <div id="expected">F[enter]::F[action]::A[enter]::A[action]::A[exit]::B[enter]::B[action]::C[action]::C[exit]::RESCUE::RESCUE::E[enter](parse)::E[action](parse id=1)::E[enter](parse)::E[action](parse id=2)::E[action](check id=3)::E[exit](check)::F[enter]::F[action]::G[enter 1]::G[enter 2]::G[enter 3]::G[enter 4]</div>
 			<h3>Actual</h3>
 			<div id="actual"></div>
 			<h3>Grade</h3>


### PR DESCRIPTION
On consecutive "rescues" I receive the following error:

_Path.routes[Path.routes.previous] is undefined (Line 51: path.js)_

**To recreate:**
1. Goto http://server/#!/home
2. Goto http://server/#!/pathdoesntexist
3. Goto http://server/#!/thispathalsodoesntexist

I checked with Firefox 4.0.1 and Safari 5.0.5 on Snow Leopard. I have modified your test files to reflect this issue. 
