### PR TITLE
Avoiding dynamic parameters from previously tested routes

### DIFF
--- a/path.js
+++ b/path.js
@@ -74,6 +74,8 @@ var Path = {
                             route.params = params;
                         }
                         return route;
+                    } else {
+                        params = {};
                     }
                 }
             }


### PR DESCRIPTION
While scanning for routes to match, a params dictionary is built up.
Even if the route does not match in the end, the params (name, value) are kept.
I don't think this is intended functionality, so I fixed it. 
