### PR TITLE
Errors in path matching in paths with repeated substrings

### DIFF
--- a/tests/path.js.test.html
+++ b/tests/path.js.test.html
@@ -15,9 +15,10 @@
 			"#E/params/3/check",
 			"#F",
 			"#G",
-                        "#H",
-                        "#H/10",
-                        "#H/10/20"
+			"#H",
+			"#H/10",
+			"#H/10/20",
+			"#I/foran/I/anda/tooth/fora/tooth"
 	    ];
 		var index = 0;
 		var timer = null;
@@ -115,11 +116,17 @@
 			    update("G[action - NOT HIT]");
 			});
 
-                        Path.map("#H(/:id_one)(/:id_two)").to(function(){
-	                    var id_one = this.params["id_one"] || "N/A";
-	                    var id_two = this.params["id_two"] || "N/A";
-                            update("H(one=" + id_one + ", two=" + id_two + ")");
-                        });
+			Path.map("#H(/:id_one)(/:id_two)").to(function(){
+				var id_one = this.params["id_one"] || "N/A";
+				var id_two = this.params["id_two"] || "N/A";
+				update("H(one=" + id_one + ", two=" + id_two + ")");
+			});
+
+			Path.map("#I/foran/:one/anda/tooth/fora/:two").to(function(){
+				var param_one = this.params["one"]; 
+				var param_two = this.params["two"]; 
+				update("I(one=" + param_one + ", two=" + param_two + ")");
+			});
 			
 			Path.rescue(function(){
 			    update("RESCUE");
@@ -176,12 +183,13 @@
 				<tr><td>H(one=N/A, two=N/A)</td>   <td>Optional parameters with only the require part submitted</td></tr>
 				<tr><td>H(one=10, two=N/A)</td>    <td>Optional parameters with one optional part submitted</td></tr>
 				<tr><td>H(one=10, two=20)</td>     <td>Optional parameters two levels deep</td></tr>
-                                <tr><td>H(one=10, two=N/A)</td>    <td>Testing "back" functionality</td></tr>
+				<tr><td>H(one=10, two=N/A)</td>    <td>Testing "back" functionality</td></tr>
+				<tr><td>I(one=I, two=tooth)</td>    <td>Matching with repeated tokens in a path</td></tr>
 			</table>
 		</div><br /><br />
 		<div id="console">
 		    <h3>Expected</h3>
-		    <div id="expected">F[enter]::F[action]::A[enter]::A[action]::A[exit]::B[enter]::B[action]::C[action]::C[exit]::RESCUE::RESCUE::E[enter](parse id=1)::E[action](parse id=1)::E[enter](parse id=2)::E[action](parse id=2)::E[action](check id=3)::E[exit](check id=3)::F[enter]::F[action]::G[enter 1]::G[enter 2]::G[enter 3]::G[enter 4]::H(one=N/A, two=N/A)::H(one=10, two=N/A)::H(one=10, two=20)::H(one=10, two=N/A)</div>
+		    <div id="expected">F[enter]::F[action]::A[enter]::A[action]::A[exit]::B[enter]::B[action]::C[action]::C[exit]::RESCUE::RESCUE::E[enter](parse id=1)::E[action](parse id=1)::E[enter](parse id=2)::E[action](parse id=2)::E[action](check id=3)::E[exit](check id=3)::F[enter]::F[action]::G[enter 1]::G[enter 2]::G[enter 3]::G[enter 4]::H(one=N/A, two=N/A)::H(one=10, two=N/A)::H(one=10, two=20)::I(one=I, two=tooth)::H(one=10, two=20)</div>
 			<h3>Actual</h3>
 			<div id="actual"></div>
 			<h3>Grade</h3>


### PR DESCRIPTION
I ran into an issue where I was expecting #/world/world/1,2 to be matched by my route #/world/:region/:coord and it wasn't. I tracked this down to the string substitution block in the 'match' method. I ended up reimplementing this block using a simple regexp and a loop through the string. 

I've updated the unit tests to add a failing test case that is fixed by this change. I'm not particular about the exact implementation, just the result. I've also created a couple of fiddles to demonstrate the problem, and the fix in action: 

Using original path.js: http://jsfiddle.net/sfoster/35Dxv/
Using the patched path.js http://jsfiddle.net/sfoster/UMPy2/
