### PR TITLE
Fix App root buggy

### DIFF
--- a/path.js
+++ b/path.js
@@ -30,7 +30,7 @@ var Path = {
             var initialPop = !Path.history.initial.popped && location.href == Path.history.initial.URL;
             Path.history.initial.popped = true;
             if(initialPop) return;
-            Path.dispatch(document.location.pathname);
+            Path.dispatch(Path.routes.root ? document.location.href : document.location.pathname);
         },
         'listen': function(fallback){
             Path.history.supported = !!(window.history && window.history.pushState);
@@ -82,6 +82,7 @@ var Path = {
     },
     'dispatch': function (passed_route) {
         var previous_route, matched_route;
+        passed_route = passed_route.replace(Path.routes.root,'');
         if (Path.routes.current !== passed_route) {
             Path.routes.previous = Path.routes.current;
             Path.routes.current = passed_route;


### PR DESCRIPTION
When you set the app root, Pathjs must always strip it from its routing system (this makes it more usable). The history popState event is buggy because window.location.pathname is not always the right argument to pass to Path.dispatch if the app root has been set.
