### PR TITLE
Reset params object with each attempted route match.

### DIFF
--- a/path.js
+++ b/path.js
@@ -59,6 +59,7 @@ var Path = {
                 route = Path.routes.defined[route];
                 possible_routes = route.partition();
                 for (j = 0; j < possible_routes.length; j++) {
+                    params = {};
                     slice = possible_routes[j];
                     compare = path;
                     if (slice.search(/:/) > 0) {

--- a/path.js
+++ b/path.js
@@ -66,7 +66,9 @@ var Path = {
                         for (i = 0; i < slice.split("/").length; i++) {
                             if ((i < compare.split("/").length) && (slice.split("/")[i].charAt(0) === ":")) {
                                 params[slice.split('/')[i].replace(/:/, '')] = compare.split("/")[i];
-                                compare = compare.replace(compare.split("/")[i], slice.split("/")[i]);
+                                compare = compare.split('/');
+                                compare[i] = slice.split('/')[i];
+                                compare = compare.join('/');
                             }
                         }
                     }


### PR DESCRIPTION
I first came across this by iterating through my definitions list using a while(i--). The params object ends up accumulating params from every possible route match that didn't match the final route. This leads to unexpected results. I've updated them the for loop to simply reset the params object at the beginning of each pass to ensure it's clean for the next pass.
