### PR TITLE
Params Object Accumulates With Each Attempt To Match A Route

### DIFF
--- a/path.js
+++ b/path.js
@@ -59,6 +59,7 @@ var Path = {
                 route = Path.routes.defined[route];
                 possible_routes = route.partition();
                 for (j = 0; j < possible_routes.length; j++) {
+                    params = {};
                     slice = possible_routes[j];
                     compare = path;
                     if (slice.search(/:/) > 0) {


### PR DESCRIPTION
I just submitted another pull request for what looks like to be the same issue, mine is #56. The gist of it is that if Path runs through several possible routes that don't match the specified route before it finally does find the correct route. In my case it was due to the order in which I had defined my routes coupled with having mapped them in reverse using a while(i--). Due to this Path was iterating through my route definition list in reverse order, which I didn't at first think about. The problem is that all params that Path comes across with each route it attempts to match are accumulated in the params object. When it finally finds the correct route it passes the whole params object to the correct route. This params object includes any params that route expects plus any that Path came across while trying to find that route. So for example:

``` javascript
var myRegisteredRoutes = [
    ['myRoute/:myParam', myHandler]
    ['myOtherRoute/:myOtherParam', myOtherHandler]
];
```

Let's suppose the route we're triggering is 'myOtherRoute/something', if we iterate through these in order we'll find that the params object passed to _myOtherHandler_ is:

``` javascript
{
    myParam: 'something',
    myOtherParam: 'something'
}
```

Obviously the problem is that myOtherHandler isn't expecting the _myParam_ parameter. So to prevent this in the match method just after _line 61_ I simply added the line:

``` javascript
params = {};
```

to reset the params object with each attempted route match. This way whatever route that is finally matched will only get the params it expects.
