### PR TITLE
Variable Values Cannot Occur As Substrings of The Full Path

### DIFF
--- a/path.js
+++ b/path.js
@@ -65,7 +65,9 @@ var Path = {
                         for (i = 0; i < slice.split("/").length; i++) {
                             if ((i < compare.split("/").length) && (slice.split("/")[i].charAt(0) === ":")) {
                                 params[slice.split('/')[i].replace(/:/, '')] = compare.split("/")[i];
-                                compare = compare.replace(compare.split("/")[i], slice.split("/")[i]);
+                                compare = compare.split('/');
+                                compare[i] = slice.split('/')[i];
+                                compare = compare.join('/');
                             }
                         }
                     }


### PR DESCRIPTION
So the example that prompted this change was a defined route of:

```
/admin/user/:username/edit/roles
```

and a passed route of:

```
/admin/user/admin/edit/roles
```

The issue here is that during the attempted matching of routes a string replace is performed to attempt to replace any occurrence of the variable's value in the string with the variable's **:name**, in this case **:username**. So in the example above after this line:

``` javascript
compare = compare.replace(compare.split("/")[i], slice.split("/")[i]);
```

the value of compare becomes:

```
/:username/user/:username/edit/roles
```

which will never match any of the defined routes. By using a string replace we're making the path extremely brittle in that the value of any route based variable can't itself occur anywhere in the path. To make this less brittle and allow for variable values to be strings that may occur in the path I simply converted the string replace line above with:

``` javascript
compare = compare.split('/');
compare[i] = slice.split('/')[i];
compare =compare.join('/');
```

Since we know the index that the variable occurs at in the route, we can replace just the value of that index in an exploded version of compare then recombine it.
