### PR TITLE
Fixed a bug pertaining to retaining parameters for ordered routes.

### DIFF
--- a/path.js
+++ b/path.js
@@ -62,14 +62,17 @@ var Path = {
                 for (j = 0; j < possible_routes.length; j++) {
                     slice = possible_routes[j];
                     compare = path;
-                    if (slice.search(/:/) > 0) {
-                        for (i = 0; i < slice.split("/").length; i++) {
-                            if ((i < compare.split("/").length) && (slice.split("/")[i].charAt(0) === ":")) {
-                                params[slice.split('/')[i].replace(/:/, '')] = compare.split("/")[i];
-                                compare = compare.replace(compare.split("/")[i], slice.split("/")[i]);
-                            }
-                        }
-                    }
+					if (slice.search(/:/) > 0) {
+						var sliceSections = slice.split("/"), compareSections = compare.split("/");
+						if (sliceSections.length == compareSections.length) {
+							for (var i = 0; i < sliceSections.length; i++)
+								if (sliceSections[i].charAt(0) === ":") {
+									params[sliceSections[i].replace(/:/, "")] = compareSections[i];
+									compareSections[i] = sliceSections[i];
+								}
+						}
+						compare = compareSections.join("/");
+					}
                     if (slice === compare) {
                         if (parameterize) {
                             route.params = params;

--- a/path.js
+++ b/path.js
@@ -53,10 +53,11 @@ var Path = {
         }
     },
     'match': function (path, parameterize) {
-        var params = {}, route = null, possible_routes, slice, i, j, compare;
+        var route = null, possible_routes, slice, i, j, compare;
         for (route in Path.routes.defined) {
-            if (route !== null && route !== undefined) {
-                route = Path.routes.defined[route];
+        	if (route !== null && route !== undefined) {
+        		var params = {};
+        		route = Path.routes.defined[route];
                 possible_routes = route.partition();
                 for (j = 0; j < possible_routes.length; j++) {
                     slice = possible_routes[j];


### PR DESCRIPTION
I have routes thus:

"#/:company-name/:project-name/dashboard"
"#/:company-name/dashboard"

When navigating to "...#/a-company/dashboard", the "project-name" parameter has the value "dashboard" bound to it. This commit fixes that problem by reinitializing the params object when examining each route. Before the commit, the params object would retain all parameters from previous routes.
